### PR TITLE
Fix antlr directory name in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def collectSourceFiles(baseDir, excludeDirs=[]):
             yield file
 
 BASE = "src/"
-ANTLR4_BASE = BASE + "antlr4-runitime-cpp/"
+ANTLR4_BASE = BASE + "antlr4-runtime-cpp/"
 ALL_SOURCE = list(collectSourceFiles(BASE, excludeDirs=[ANTLR4_BASE]))
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,13 @@ hdlConvertor = Extension('hdlConvertor',
                     extra_compile_args=['-std=c++11'],
                     sources=ALL_SOURCE,
                     language="c++",
+                    define_macros=[('ANTLR4CPP_STATIC',None)]
                     )
 
 antlr4 = ('antlr4',
-          {'sources': list(collectSourceFiles(ANTLR4_BASE))
+          {'sources': list(collectSourceFiles(ANTLR4_BASE)),
+          'macros': [('ANTLR4CPP_STATIC', None)],
+          'include_dirs': [ANTLR4_BASE]
           }
          )
 

--- a/src/convertor.h
+++ b/src/convertor.h
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <fstream>
-#include <unistd.h>
 
 #include "hdlObjects/context.h"
 #include "antlr4-runtime.h"

--- a/src/hdlObjects/expr.cpp
+++ b/src/hdlObjects/expr.cpp
@@ -2,7 +2,7 @@
 #include "symbol.h"
 #include "operator.h"
 
-LiteralVal __v ={._str= NULL};
+LiteralVal __v ={NULL};
 static Symbol Type_t(symbol_T, __v); // symbol representing that expr is type of type;
 
 Expr::Expr() {

--- a/src/parserContainer.h
+++ b/src/parserContainer.h
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <fstream>
-#include <unistd.h>
 #include <functional>
 
 #include "hdlObjects/context.h"


### PR DESCRIPTION
The directory name contained an extra 'i', which prevented the antlr4 library from compiling.