### PR TITLE
fix for setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python version](https://img.shields.io/pypi/pyversions/hdlConvertor.svg)](https://img.shields.io/pypi/pyversions/hdlConvertor.svg)
 [ROADMAP](https://drive.google.com/file/d/1zyegLIf7VaBRyb-ED5vgOMmHzW4SRZLp/view?usp=sharing)
 
+This is a development branch. Please use the original from https://github.com/Nic30/hdlConvertor
 
 The System Verilog and VHDL parser (and preprocessor) for Python/C++ written in C++. The lower layers are ANTLR4 generated parsers with full language support. Next layer converts this raw Verilog/VHDL AST to simple universal AST. So your project does not not have to care about Verilog/VHDL differences
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Python version](https://img.shields.io/pypi/pyversions/hdlConvertor.svg)](https://img.shields.io/pypi/pyversions/hdlConvertor.svg)
 [ROADMAP](https://drive.google.com/file/d/1zyegLIf7VaBRyb-ED5vgOMmHzW4SRZLp/view?usp=sharing)
 
-This is a development branch. Please use the original from https://github.com/Nic30/hdlConvertor
 
 The System Verilog and VHDL parser (and preprocessor) for Python/C++ written in C++. The lower layers are ANTLR4 generated parsers with full language support. Next layer converts this raw Verilog/VHDL AST to simple universal AST. So your project does not not have to care about Verilog/VHDL differences
 
@@ -99,3 +98,4 @@ for o in d.objs:
 
 License in top folder applies to this project only.
 In this repository there are also ANTLR4 grammars (.g4 files - BSD 3, GPL-3, GPL, however they are not present in installation).
+

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         'Programming Language :: Python :: 2.7'
         'Programming Language :: Python :: 3',
     ],
-    packages=['hdlConvertor'],
+    packages=['hdlConvertor', 'hdlConvertor/hdlAst'],
 )


### PR DESCRIPTION
Hi, 
When making a proper setup I made a wheel (python setup.py bdist_wheel) but that did not install the package hdlConvertor/hdlAst, so I added it to the setup.py file.

please ignore the readme.md github immediately commits changes, and i first tried to indicate that this was not the original.

Kind regards, Paul