### PR TITLE
Fixes to exception throwing in language detection

### DIFF
--- a/hdlConvertor/_hdlConvertor.pyx
+++ b/hdlConvertor/_hdlConvertor.pyx
@@ -102,7 +102,7 @@ cdef class HdlConvertor:
         """
         :param filenames: sequence of filenames or filename
         :type filename: Union[str, List[str]]
-        :param language: hdlConvertor.language.Language enum value
+        :param langue: hdlConvertor.language.Language enum value
         :param incdirs: list of include directories
         :param hierarchyOnly: if True only names of components and modules are parsed
         :param debug: if True the debug logging is enabled
@@ -144,7 +144,7 @@ cdef class HdlConvertor:
         """
         :param hdl_str: HDL string to parse
         :type filename: str
-        :param language: hdlConvertor.language.Language enum value
+        :param langue: hdlConvertor.language.Language enum value
         :param incdirs: list of include directories
         :param hierarchyOnly: if True only names of components and modules are parsed
         :param debug: if True the debug logging is enabled

--- a/hdlConvertor/_hdlConvertor.pyx
+++ b/hdlConvertor/_hdlConvertor.pyx
@@ -82,7 +82,7 @@ cdef class HdlConvertor:
         elif langue == PyHdlLanguageEnum.SYSTEM_VERILOG:
             return SYSTEM_VERILOG
         else:
-            raise ValueError(langue + " is not recognized (expected verilog, vhdl or systemVerilog)")
+            raise ValueError(str(langue) + " is not recognized (expected verilog, vhdl or systemVerilog)")
 
     @staticmethod
     def _get_verilog_pp_mode(mode):

--- a/tests/test_verilog_preproc.py
+++ b/tests/test_verilog_preproc.py
@@ -145,6 +145,20 @@ class VerilogPreprocTC(unittest.TestCase):
         test_golden += "\"" + expected_val + "\", 5);\n\n\nendmodule\n"
         self.assertEqual(test_result, test_golden)
 
+    def test_verilog_pp_Language_is_bad(self):
+        with self.assertRaises(ValueError) as context:
+            c = HdlConvertor()
+            test_result = c.verilog_pp("", "", "badlang")
+        e = str(context.exception)
+        self.assertIn("badlang is not recognized (expected <enum 'Language'>)", e)
+
+    def test_parser_Language_is_bad(self):
+        with self.assertRaises(ValueError) as context:
+            c = HdlConvertor()
+            test_result = c.parse(None, Language.SYSTEM_VERILOG_2012, None)
+        e = str(context.exception)
+        self.assertIn("Language.SYSTEM_VERILOG_2012 is not recognized (expected verilog, vhdl or systemVerilog", e)
+
     # def test_debug_macro(self):
     #     c = HdlConvertor()
     #     f = path.join(*SRC_DIR,'debug_macro.sv')


### PR DESCRIPTION
1. Fix parameter typo in docstring.
2. Convert variable to string to ensure exception is thrown correctly when user passes an enum.
3. Add corresponding tests