### PR TITLE
Issue #88 - Populate missing positional information for objects

### DIFF
--- a/include/hdlConvertor/createObject.h
+++ b/include/hdlConvertor/createObject.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <hdlConvertor/hdlObjects/iHdlObj.h>
+#include <hdlConvertor/hdlObjects/named.h>
+
+#include <memory>
+
+namespace antlr4
+{
+	class ParserRuleContext;
+	namespace tree
+	{
+		class ParseTree;
+		class TreeNode;
+	}
+}
+
+namespace hdlConvertor {
+	template<typename T, typename... Args>
+	std::unique_ptr<T> create_object(antlr4::tree::ParseTree *const node, Args &&... args) {
+		std::unique_ptr<T> object = std::make_unique<T>(std::forward<Args>(args)...);
+		if (node) {
+			antlr4::ParserRuleContext *ctx = dynamic_cast<antlr4::ParserRuleContext *>(node);
+			if (!ctx) {
+				antlr4::tree::TerminalNode *const tn = dynamic_cast<antlr4::tree::TerminalNode *>(node);
+				if (tn && tn->parent) {
+					ctx = dynamic_cast<antlr4::ParserRuleContext *>(tn->parent);
+				}
+			}
+
+			if (ctx) {
+				auto wp = dynamic_cast<hdlObjects::WithPos *>(object.get());
+				if (wp) {
+					wp->position.update_from_elem(ctx);
+				}
+			}
+		}
+		return object;
+	}
+}

--- a/include/hdlConvertor/createObject.h
+++ b/include/hdlConvertor/createObject.h
@@ -3,6 +3,8 @@
 #include <hdlConvertor/hdlObjects/iHdlObj.h>
 #include <hdlConvertor/hdlObjects/named.h>
 
+#include <tree/TerminalNode.h>
+
 #include <memory>
 
 namespace antlr4

--- a/include/hdlConvertor/createObject.h
+++ b/include/hdlConvertor/createObject.h
@@ -3,19 +3,9 @@
 #include <hdlConvertor/hdlObjects/iHdlObj.h>
 #include <hdlConvertor/hdlObjects/named.h>
 
-#include <tree/TerminalNode.h>
+#include <antlr4-runtime.h>
 
 #include <memory>
-
-namespace antlr4
-{
-	class ParserRuleContext;
-	namespace tree
-	{
-		class ParseTree;
-		class TreeNode;
-	}
-}
 
 namespace hdlConvertor {
 	template<typename T, typename... Args>

--- a/include/hdlConvertor/hdlObjects/iHdlExpr.h
+++ b/include/hdlConvertor/hdlObjects/iHdlExpr.h
@@ -11,6 +11,15 @@
 #include <hdlConvertor/hdlObjects/named.h>
 #include <hdlConvertor/hdlObjects/iHdlObj.h>
 
+namespace antlr4
+{
+	class ParserRuleContext;
+	namespace tree
+	{
+		class TerminalNode;
+	}
+}
+
 namespace hdlConvertor {
 namespace hdlObjects {
 
@@ -22,6 +31,9 @@ namespace hdlObjects {
  */
 class iHdlExpr: public WithPos, public iHdlObj {
 public:
+	using TerminalNode = antlr4::tree::TerminalNode;
+	using ParserRuleContext = antlr4::ParserRuleContext;
+
 	iHdlExprItem *data;
 
 	iHdlExpr();
@@ -41,25 +53,30 @@ public:
 	static std::unique_ptr<iHdlExpr> TYPE_T();
 	static std::unique_ptr<iHdlExpr> AUTO_T();
 
-	static std::unique_ptr<iHdlExpr> INT(int64_t val);
-	static std::unique_ptr<iHdlExpr> INT(const std::string &strVal, int base);
-	static std::unique_ptr<iHdlExpr> INT(const std::string &strVal, int bits,
+	static std::unique_ptr<iHdlExpr> INT(TerminalNode *node, int64_t val);
+	static std::unique_ptr<iHdlExpr> INT(TerminalNode *node, const std::string &strVal, int base);
+	static std::unique_ptr<iHdlExpr> INT(TerminalNode *node, const std::string &strVal, int bits,
 			int base);
-	static std::unique_ptr<iHdlExpr> FLOAT(double val);
-	static std::unique_ptr<iHdlExpr> STR(std::string strVal);
-	static std::unique_ptr<iHdlExpr> ARRAY(
+	static std::unique_ptr<iHdlExpr> FLOAT(TerminalNode *node, double val);
+	static std::unique_ptr<iHdlExpr> STR(TerminalNode *node, std::string strVal);
+	static std::unique_ptr<iHdlExpr> ARRAY(ParserRuleContext *ctx,
 			std::vector<std::unique_ptr<iHdlExpr>> &arr);
-	static std::unique_ptr<iHdlExpr> ARRAY(
+	static std::unique_ptr<iHdlExpr> ARRAY(ParserRuleContext *ctx,
 			std::unique_ptr<std::vector<std::unique_ptr<iHdlExpr>>> arr);
-	static std::unique_ptr<iHdlExpr> ternary(std::unique_ptr<iHdlExpr> cond,
+	static std::unique_ptr<iHdlExpr> ternary(ParserRuleContext *ctx,
+			std::unique_ptr<iHdlExpr> cond,
 			std::unique_ptr<iHdlExpr> ifTrue,
 			std::unique_ptr<iHdlExpr> ifFalse);
-	static std::unique_ptr<iHdlExpr> call(std::unique_ptr<iHdlExpr> fnId,
-			std::vector<std::unique_ptr<iHdlExpr>> &args);
-	static std::unique_ptr<iHdlExpr> parametrization(
+	static std::unique_ptr<iHdlExpr> call(ParserRuleContext *ctx,
 			std::unique_ptr<iHdlExpr> fnId,
 			std::vector<std::unique_ptr<iHdlExpr>> &args);
-	static std::unique_ptr<iHdlExpr> slice(std::unique_ptr<iHdlExpr> fnId,
+	static std::unique_ptr<iHdlExpr> parametrization(
+			ParserRuleContext *ctx,
+			std::unique_ptr<iHdlExpr> fnId,
+			std::vector<std::unique_ptr<iHdlExpr>> &args);
+	static std::unique_ptr<iHdlExpr> slice(
+			ParserRuleContext *ctx,
+			std::unique_ptr<iHdlExpr> fnId,
 			std::vector<std::unique_ptr<iHdlExpr>> &operands);
 
 	static std::unique_ptr<iHdlExpr> OPEN();

--- a/include/hdlConvertor/hdlObjects/position.h
+++ b/include/hdlConvertor/hdlObjects/position.h
@@ -6,7 +6,9 @@ namespace hdlConvertor {
 namespace hdlObjects {
 
 /*
- * Container for position in code
+ * Container for position in code.
+ * NOTE: stopXX are inclusive coordinates and not one beyond i.e. [startXXX, stopXXX] and not [startXXX, stopXXX)
+ * Also, corrdinates are 1-based indexing i.e. first line and column is indexed as 1 and not 0.
  * */
 class Position {
 public:
@@ -24,6 +26,9 @@ public:
 	void update_from_elem(ELEM_T *elem) {
 		startLine = elem->getStart()->getLine();
 		stopLine = elem->getStop()->getLine();
+		startColumn = elem->getStart()->getCharPositionInLine() + 1;
+		stopColumn = elem->getStop()->getCharPositionInLine() +
+				(elem->getStop()->getStopIndex() - elem->getStop()->getStartIndex()) + 1;
 	}
 	bool isKnown() const;
 };

--- a/include/hdlConvertor/svConvertor/literalParser.h
+++ b/include/hdlConvertor/svConvertor/literalParser.h
@@ -10,12 +10,13 @@ class VerLiteralParser {
 public:
 	using sv2017Parser = sv2017_antlr::sv2017Parser;
 	using TerminalNode = antlr4::tree::TerminalNode;
+
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitIntegral_number(
 			sv2017Parser::Integral_numberContext *ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitUNSIGNED_NUMBER(TerminalNode *ctx);
 	static size_t parseSize_UNSIGNED_NUMBER(std::string str);
-	static std::unique_ptr<hdlObjects::iHdlExpr> visitANY_BASED_NUMBER(std::string str,
-			size_t size);
+	static std::unique_ptr<hdlObjects::iHdlExpr> visitANY_BASED_NUMBER(
+			sv2017Parser::Integral_numberContext *ctx, std::string str, size_t size);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitNumber(sv2017Parser::NumberContext *ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitSIMPLE_IDENTIFIER(TerminalNode *n);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitC_IDENTIFIER(TerminalNode *n);

--- a/include/hdlConvertor/svConvertor/utils.h
+++ b/include/hdlConvertor/svConvertor/utils.h
@@ -4,6 +4,11 @@
 #include <hdlConvertor/hdlObjects/iHdlExpr.h>
 #include <hdlConvertor/hdlObjects/hdlOperatorType.h>
 
+namespace antlr4
+{
+	class ParserRuleContext;
+}
+
 namespace hdlConvertor {
 namespace sv {
 
@@ -15,13 +20,16 @@ public:
 	// wire type is represented by wire id or call wire(range, signed)
 	static std::unique_ptr<hdlObjects::iHdlExpr> mkWireT();
 	static std::unique_ptr<hdlObjects::iHdlExpr> mkWireT(
+			antlr4::ParserRuleContext *const ctx,
 			std::unique_ptr<hdlObjects::iHdlExpr> range, bool signed_);
 	static std::unique_ptr<hdlObjects::iHdlExpr> mkWireT(
+			antlr4::ParserRuleContext *const ctx,
 			std::unique_ptr<hdlObjects::iHdlExpr> net_type,
 			std::unique_ptr<hdlObjects::iHdlExpr> range, bool signed_);
 };
 
 std::unique_ptr<hdlObjects::iHdlExpr> append_expr(
+		antlr4::ParserRuleContext *const ctx,
 		std::unique_ptr<hdlObjects::iHdlExpr> selected_name,
 		hdlObjects::HdlOperatorType operator_to_join_with,
 		std::unique_ptr<hdlObjects::iHdlExpr> new_part);

--- a/include/hdlConvertor/vhdlConvertor/literalParser.h
+++ b/include/hdlConvertor/vhdlConvertor/literalParser.h
@@ -4,12 +4,23 @@
 
 #include <hdlConvertor/hdlObjects/iHdlExpr.h>
 
+namespace antlr4
+{
+  class ParserRuleContext;
+  namespace tree
+  {
+    class TerminalNode;
+  }
+}
+
 namespace hdlConvertor {
 namespace vhdl {
 
 class VhdlLiteralParser {
 public:
 	using vhdlParser = vhdl_antlr::vhdlParser;
+  using TerminalNode = antlr4::tree::TerminalNode;
+  using ParserRuleContext = antlr4::ParserRuleContext;
 
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitNumeric_literal(
 			vhdlParser::Numeric_literalContext *ctx);
@@ -18,15 +29,15 @@ public:
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitEnumeration_literal(
 			vhdlParser::Enumeration_literalContext *ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitSTRING_LITERAL(
-			const std::string &ctx);
+			TerminalNode *n, const std::string &ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitCHARACTER_LITERAL(
-			const std::string &ctx);
+			TerminalNode *n, const std::string &ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitBIT_STRING_LITERAL(
-			const std::string &s);
+			TerminalNode *ctx, const std::string &s);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitDECIMAL_LITERAL(
-			antlr4::tree::TerminalNode *ctx);
+			TerminalNode *ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitBASED_LITERAL(
-			antlr4::tree::TerminalNode *ctx);
+			TerminalNode *ctx);
 	static std::unique_ptr<hdlObjects::iHdlExpr> visitIdentifier(
 			vhdlParser::IdentifierContext *ctx);
 	static std::string getIdentifierStr(vhdlParser::IdentifierContext *ctx);

--- a/src/hdlObjects/hdlStmProcess.cpp
+++ b/src/hdlObjects/hdlStmProcess.cpp
@@ -3,8 +3,6 @@
 
 #include <hdlConvertor/createObject.h>
 
-#include <antlr4-runtime.h>
-
 using namespace std;
 
 namespace hdlConvertor {

--- a/src/hdlObjects/hdlStmProcess.cpp
+++ b/src/hdlObjects/hdlStmProcess.cpp
@@ -1,19 +1,23 @@
 #include <hdlConvertor/hdlObjects/hdlStmProcess.h>
 #include <hdlConvertor/hdlObjects/hdlStmBlock.h>
 
+#include <hdlConvertor/createObject.h>
+
+#include <antlr4-runtime.h>
+
 using namespace std;
 
 namespace hdlConvertor {
 namespace hdlObjects {
 
 HdlStmProcess::HdlStmProcess() :
-		iHdlStatement(), body(make_unique<HdlStmBlock>()) {
+		iHdlStatement(), body(create_object<HdlStmBlock>(nullptr)) {
 }
 
 HdlStmProcess::HdlStmProcess(
 		unique_ptr<vector<unique_ptr<iHdlExpr>>> _sensitivity) :
 		iHdlStatement(), sensitivity_list(move(_sensitivity)), body(
-				make_unique<HdlStmBlock>()) {
+				create_object<HdlStmBlock>(nullptr)) {
 }
 HdlStmProcess::HdlStmProcess(
 		unique_ptr<vector<unique_ptr<iHdlExpr>>> _sensitivity,

--- a/src/hdlObjects/iHdlExpr.cpp
+++ b/src/hdlObjects/iHdlExpr.cpp
@@ -6,8 +6,6 @@
 #include <hdlConvertor/hdlObjects/hdlCall.h>
 #include <hdlConvertor/createObject.h>
 
-#include <antlr4-runtime.h>
-
 using namespace std;
 
 namespace hdlConvertor {

--- a/src/svConvertor/declrParser.cpp
+++ b/src/svConvertor/declrParser.cpp
@@ -3,6 +3,7 @@
 #include <hdlConvertor/svConvertor/paramDefParser.h>
 #include <hdlConvertor/svConvertor/exprParser.h>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 
 using namespace std;
@@ -111,7 +112,7 @@ void VerDeclrParser::visitList_of_variable_decl_assignments(
 				}
 			}
 		}
-		auto var = make_unique<HdlVariableDef>(name, move(t), move(v));
+		auto var = create_object<HdlVariableDef>(vda, name, move(t), move(v));
 		res.push_back(move(var));
 	}
 
@@ -137,21 +138,21 @@ unique_ptr<HdlVariableDef> VerDeclrParser::visitType_declaration(
 		auto vds = ctx->variable_dimension();
 		dt = tp.applyVariable_dimension(move(dt), vds);
 		auto name = ep.getIdentifierStr(id0);
-		return make_unique<HdlVariableDef>(name, iHdlExpr::TYPE_T(), move(dt));
+		return create_object<HdlVariableDef>(ctx, name, iHdlExpr::TYPE_T(), move(dt));
 	} else if (ctx->KW_ENUM() || ctx->KW_STRUCT() || ctx->KW_UNION()
 			|| ctx->KW_CLASS()) {
 		// forward typedef without actual type specified
 		auto name = ep.getIdentifierStr(id0);
-		return make_unique<HdlVariableDef>(name, iHdlExpr::TYPE_T(), iHdlExpr::null());
+		return create_object<HdlVariableDef>(ctx, name, iHdlExpr::TYPE_T(), iHdlExpr::null());
 	} else {
 		auto iwbs = ctx->identifier_with_bit_select();
 		auto val = ep.visitIdentifier_with_bit_select(iwbs, nullptr);
 		auto ids = ctx->identifier();
 		assert(ids.size() == 2);
 		auto id = ep.visitIdentifier(ids[0]);
-		val = make_unique<iHdlExpr>(move(val), HdlOperatorType::DOT, move(id));
+		val = create_object<iHdlExpr>(iwbs, move(val), HdlOperatorType::DOT, move(id));
 		auto name = ep.getIdentifierStr(ids[1]);
-		return make_unique<HdlVariableDef>(name, iHdlExpr::TYPE_T(), move(val));
+		return create_object<HdlVariableDef>(ctx, name, iHdlExpr::TYPE_T(), move(val));
 	}
 }
 void VerDeclrParser::visitNet_type_declaration(

--- a/src/svConvertor/eventExprParser.cpp
+++ b/src/svConvertor/eventExprParser.cpp
@@ -1,6 +1,7 @@
 #include <hdlConvertor/svConvertor/eventExprParser.h>
 #include <memory>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/svConvertor/exprParser.h>
 #include <hdlConvertor/notImplementedLogger.h>
 
@@ -46,7 +47,7 @@ void VerEventExprParser::visitEvent_expression_item(
 			// [todo] must have
 			auto edge_type = visitEvent_identifier(ei);
 			if (edge_type.second)
-				e = make_unique<iHdlExpr>(edge_type.first, move(e));
+				e = create_object<iHdlExpr>(_e[0], edge_type.first, move(e));
 		}
 		if (_e.size() != 1) {
 			NotImplementedLogger::print(

--- a/src/svConvertor/exprPrimaryParser.cpp
+++ b/src/svConvertor/exprPrimaryParser.cpp
@@ -5,6 +5,7 @@
 #include <hdlConvertor/svConvertor/typeParser.h>
 #include <hdlConvertor/svConvertor/utils.h>
 #include <hdlConvertor/notImplementedLogger.h>
+#include <hdlConvertor/createObject.h>
 
 using namespace std;
 using sv2017Parser = sv2017_antlr::sv2017Parser;
@@ -169,7 +170,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCast2(
 	auto _e = ctx->expression();
 	VerExprParser ep(commentParser);
 	auto e = ep.visitExpression(_e);
-	return make_unique<iHdlExpr>(move(p), HdlOperatorType::CALL, move(e));
+	return create_object<iHdlExpr>(ctx, move(p), HdlOperatorType::CALL, move(e));
 }
 
 unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryBitSelect(
@@ -189,7 +190,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryDot(
 	auto p = visitPrimary(_p);
 	auto _id = ctx->identifier();
 	auto id = VerExprParser::visitIdentifier(_id);
-	return append_expr(move(p), HdlOperatorType::DOT, move(id));
+	return append_expr(_p, move(p), HdlOperatorType::DOT, move(id));
 }
 
 unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryIndex(
@@ -200,7 +201,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryIndex(
 	auto _are = ctx->array_range_expression();
 	VerExprParser ep(commentParser);
 	auto are = ep.visitArray_range_expression(_are);
-	p = append_expr(move(p), HdlOperatorType::INDEX, move(are));
+	p = append_expr(_p, move(p), HdlOperatorType::INDEX, move(are));
 	return p;
 }
 
@@ -246,7 +247,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryTfCall(
 				"VerExprPrimaryParser.visitPrimaryTfCall.clocking_event", ctx);
 		// args.push_back(ep.visitClocking_event(ce));
 	}
-	return iHdlExpr::call(move(id), args);
+	return iHdlExpr::call(ctx, move(id), args);
 }
 
 unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryRandomize(
@@ -304,7 +305,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCall(
 	auto loa = ctx->list_of_arguments();
 	if (loa)
 		ep.visitList_of_arguments(loa, args);
-	return iHdlExpr::call(move(p), args);
+	return iHdlExpr::call(ctx, move(p), args);
 }
 
 unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCallArrayMethodNoArgs(
@@ -322,7 +323,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCallArrayMethodNoArgs(
 
 	VerExprParser ep(commentParser);
 	vector<unique_ptr<iHdlExpr>> args;
-	return iHdlExpr::call(move(p), args);
+	return iHdlExpr::call(ctx, move(p), args);
 }
 
 unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCallWith(
@@ -347,7 +348,7 @@ unique_ptr<iHdlExpr> VerExprPrimaryParser::visitPrimaryCallWith(
 
 	VerExprParser ep(commentParser);
 	vector<unique_ptr<iHdlExpr>> args;
-	return iHdlExpr::call(move(p), args);
+	return iHdlExpr::call(ctx, move(p), args);
 }
 
 }

--- a/src/svConvertor/moduleInstanceParser.cpp
+++ b/src/svConvertor/moduleInstanceParser.cpp
@@ -1,5 +1,6 @@
 #include <hdlConvertor/svConvertor/moduleInstanceParser.h>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/svConvertor/exprParser.h>
 #include <hdlConvertor/svConvertor/paramDefParser.h>
@@ -83,7 +84,7 @@ vector<unique_ptr<iHdlExpr>> VerModuleInstanceParser::visitList_of_parameter_val
 				v = iHdlExpr::null();
 			}
 			pcs.push_back(
-					make_unique<iHdlExpr>(move(k),
+					create_object<iHdlExpr>(pa, move(k),
 							HdlOperatorType::MAP_ASSOCIATION, move(v)));
 		}
 	}
@@ -106,7 +107,7 @@ unique_ptr<HdlCompInstance> VerModuleInstanceParser::visitHierarchical_instance(
 	name = tp.applyUnpacked_dimension(move(name), uds);
 	auto portMap = visitList_of_port_connections(
 			ctx->list_of_port_connections());
-	auto c = make_unique<HdlCompInstance>(move(name), move(module_id));
+	auto c = create_object<HdlCompInstance>(ctx, move(name), move(module_id));
 	c->genericMap = move(genericMap);
 	c->portMap = move(portMap);
 	return c;
@@ -168,7 +169,7 @@ vector<unique_ptr<iHdlExpr>> VerModuleInstanceParser::visitList_of_port_connecti
 				v = iHdlExpr::null();
 			}
 			pcs.push_back(
-					make_unique<iHdlExpr>(move(k),
+					create_object<iHdlExpr>(pc, move(k),
 							HdlOperatorType::MAP_ASSOCIATION, move(v)));
 		}
 	}

--- a/src/svConvertor/moduleParser.cpp
+++ b/src/svConvertor/moduleParser.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/conversion_exception.h>
 #include <hdlConvertor/hdlObjects/hdlStm_others.h>
@@ -63,7 +64,8 @@ void VerModuleParser::visitModule_declaration(
 	//      KW_ENDMODULE ( COLON identifier | {_input->LA(1) != COLON}? )
 	// ;
 	auto mhc = ctx->module_header_common();
-	auto ent = make_unique<HdlModuleDec>();
+	auto ent = create_object<HdlModuleDec>(ctx);
+
 	ModuleCtx m_ctx(*ent);
 	visitModule_header_common(mhc, *ent);
 
@@ -76,7 +78,7 @@ void VerModuleParser::visitModule_declaration(
 		}
 	} else {
 		if (ctx->MUL()) {
-			auto p = make_unique<HdlVariableDef>(".*", iHdlExpr::all(),
+			auto p = create_object<HdlVariableDef>(ctx, ".*", iHdlExpr::all(),
 					nullptr);
 			ent->ports.push_back(move(p));
 		}
@@ -96,7 +98,7 @@ void VerModuleParser::visitModule_declaration(
 		return;
 	}
 
-	auto arch = make_unique<HdlModuleDef>();
+	auto arch = create_object<HdlModuleDef>(ctx);
 	m_ctx.arch = arch.get();
 	auto tid = ctx->timeunits_declaration();
 	if (tid) {
@@ -253,7 +255,7 @@ void VerModuleParser::visitModule_item_item(
 	}
 	{
 		if (ctx->SEMI()) {
-			res_stm.push_back(make_unique<HdlStmNop>());
+			res_stm.push_back(create_object<HdlStmNop>(ctx));
 			return;
 		}
 	}
@@ -522,10 +524,6 @@ void VerModuleParser::visitModule_item(sv2017Parser::Module_itemContext *ctx,
 			iHdlObj *_last = objs[prev_size].get();
 			auto wd = dynamic_cast<WithDoc*>(_last);
 			wd->__doc__ = doc + wd->__doc__;
-			auto wp = dynamic_cast<WithPos*>(_last);
-			if (wp) {
-				wp->position.update_from_elem(ctx);
-			}
 		}
 		return;
 	}
@@ -698,7 +696,7 @@ void VerModuleParser::visitList_of_net_decl_assignments(
 		}
 		auto uds = nd->unpacked_dimension();
 		t = tp.applyUnpacked_dimension(move(t), uds);
-		auto v = make_unique<HdlVariableDef>(id, move(t), move(def_val));
+		auto v = create_object<HdlVariableDef>(nd, id, move(t), move(def_val));
 		if (first) {
 			first = false;
 		}

--- a/src/svConvertor/paramDefParser.cpp
+++ b/src/svConvertor/paramDefParser.cpp
@@ -2,6 +2,7 @@
 
 #include <hdlConvertor/svConvertor/utils.h>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 
 #include <hdlConvertor/svConvertor/typeParser.h>
@@ -132,7 +133,7 @@ void VerParamDefParser::visitList_of_type_assignments(
 		auto _v = _ta->data_type();
 		if (_v)
 			v = tp.visitData_type(_v);
-		auto ta = make_unique<HdlVariableDef>(name, iHdlExpr::TYPE_T(),
+		auto ta = create_object<HdlVariableDef>(_ta, name, iHdlExpr::TYPE_T(),
 				move(v));
 		res.push_back(move(ta));
 	}
@@ -148,7 +149,7 @@ unique_ptr<HdlVariableDef> VerParamDefParser::visitParam_assignment(
 		value = visitConstant_param_expression(cpa);
 	}
 	auto name = VerExprParser::getIdentifierStr(ctx->identifier());
-	auto p = make_unique<HdlVariableDef>(name, iHdlExpr::AUTO_T(), move(value));
+	auto p = create_object<HdlVariableDef>(ctx, name, iHdlExpr::AUTO_T(), move(value));
 	p->__doc__ += commentParser.parse(ctx);
 	return p;
 }

--- a/src/svConvertor/programParser.cpp
+++ b/src/svConvertor/programParser.cpp
@@ -1,5 +1,6 @@
 #include <hdlConvertor/svConvertor/programParser.h>
 
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 
 #include <hdlConvertor/svConvertor/typeParser.h>
@@ -88,7 +89,7 @@ std::unique_ptr<HdlFunctionDef> VerProgramParser::visitTask_and_function_declara
 		name = VerExprParser::getIdentifierStr(ids[0]);
 	}
 	auto params = make_unique<std::vector<unique_ptr<HdlVariableDef>>>();
-	auto f = make_unique<HdlFunctionDef>(name, false, move(return_t),
+	auto f = create_object<HdlFunctionDef>(ctx, name, false, move(return_t),
 			move(params));
 	f->is_static = is_static;
 	f->is_task = is_task;

--- a/src/svConvertor/utils.cpp
+++ b/src/svConvertor/utils.cpp
@@ -4,6 +4,8 @@
 #include <hdlConvertor/hdlObjects/hdlValue.h>
 #include <hdlConvertor/svConvertor/sv2017Parser/sv2017Lexer.h>
 
+#include <hdlConvertor/createObject.h>
+
 using sv2017Parser = sv2017_antlr::sv2017Parser;
 using namespace hdlConvertor::hdlObjects;
 using namespace std;
@@ -23,25 +25,29 @@ unique_ptr<iHdlExpr> Utils::mkWireT() {
 	return iHdlExpr::ID("wire");
 }
 
-unique_ptr<iHdlExpr> Utils::mkWireT(unique_ptr<iHdlExpr> range, bool signed_) {
-	return mkWireT(nullptr, move(range), signed_);
+unique_ptr<iHdlExpr> Utils::mkWireT(
+		antlr4::ParserRuleContext *const ctx, unique_ptr<iHdlExpr> range, bool signed_) {
+	return mkWireT(ctx, nullptr, move(range), signed_);
 }
 
-unique_ptr<iHdlExpr> Utils::mkWireT(unique_ptr<iHdlExpr> net_type,
+unique_ptr<iHdlExpr> Utils::mkWireT(
+		antlr4::ParserRuleContext *const ctx,
+		unique_ptr<iHdlExpr> net_type,
 		unique_ptr<iHdlExpr> range, bool signed_) {
 	vector<unique_ptr<iHdlExpr>> operands;
-	operands.push_back(iHdlExpr::INT(signed_ ? 1 : 0));
+	operands.push_back(iHdlExpr::INT(nullptr, signed_ ? 1 : 0));
 	if (net_type == nullptr)
 		net_type = mkWireT();
-	net_type = iHdlExpr::parametrization(move(net_type), operands);
-	return make_unique<iHdlExpr>(move(net_type), HdlOperatorType::INDEX,
+	net_type = iHdlExpr::parametrization(ctx, move(net_type), operands);
+	return create_object<iHdlExpr>(ctx, move(net_type), HdlOperatorType::INDEX,
 			move(range));
 }
 
-unique_ptr<iHdlExpr> append_expr(unique_ptr<iHdlExpr> selected_name,
+unique_ptr<iHdlExpr> append_expr(
+		antlr4::ParserRuleContext *const ctx, unique_ptr<iHdlExpr> selected_name,
 		HdlOperatorType operator_to_join_with, unique_ptr<iHdlExpr> new_part) {
 	if (selected_name) {
-		return make_unique<iHdlExpr>(move(selected_name), operator_to_join_with,
+		return create_object<iHdlExpr>(ctx, move(selected_name), operator_to_join_with,
 				move(new_part));
 	} else {
 		return new_part;

--- a/src/vhdlConvertor/archParser.cpp
+++ b/src/vhdlConvertor/archParser.cpp
@@ -3,6 +3,8 @@
 #include <hdlConvertor/vhdlConvertor/referenceParser.h>
 #include <hdlConvertor/vhdlConvertor/statementParser.h>
 
+#include <hdlConvertor/createObject.h>
+
 namespace hdlConvertor {
 namespace vhdl {
 
@@ -14,7 +16,7 @@ VhdlArchParser::VhdlArchParser(bool _hierarchyOnly) {
 }
 std::unique_ptr<HdlModuleDef> VhdlArchParser::visitArchitecture_body(
 		vhdlParser::Architecture_bodyContext * ctx) {
-	auto a = std::make_unique<HdlModuleDef>();
+	auto a = create_object<HdlModuleDef>(ctx);
 	// architecture_body:
 	//       ARCHITECTURE identifier OF name IS
 	//           ( block_declarative_item )*
@@ -25,7 +27,6 @@ std::unique_ptr<HdlModuleDef> VhdlArchParser::visitArchitecture_body(
 
 	a->name = ctx->identifier(0)->getText();
 	a->entityName = VhdlReferenceParser::visitName(ctx->name());
-	a->position.update_from_elem(ctx);
 
 	if (!hierarchyOnly) {
 		for (auto bi : ctx->block_declarative_item()) {

--- a/src/vhdlConvertor/blockDeclarationParser.cpp
+++ b/src/vhdlConvertor/blockDeclarationParser.cpp
@@ -8,6 +8,9 @@
 #include <hdlConvertor/vhdlConvertor/subProgramParser.h>
 #include <hdlConvertor/vhdlConvertor/subtypeDeclarationParser.h>
 #include <hdlConvertor/vhdlConvertor/variableParser.h>
+
+#include <hdlConvertor/createObject.h>
+
 #include <string.h>
 
 namespace hdlConvertor {
@@ -186,7 +189,7 @@ std::unique_ptr<hdlObjects::HdlModuleDec> VhdlBlockDeclarationParser::visitCompo
 	//           ( port_clause )?
 	//       END COMPONENT ( identifier )? SEMI
 	// ;
-	auto e = std::make_unique<hdlObjects::HdlModuleDec>();
+	auto e = create_object<hdlObjects::HdlModuleDec>(ctx);
 	e->name = ctx->identifier(0)->getText();
 	if (!hierarchyOnly) {
 		auto gc = ctx->generic_clause();

--- a/src/vhdlConvertor/compInstanceParser.cpp
+++ b/src/vhdlConvertor/compInstanceParser.cpp
@@ -4,6 +4,8 @@
 #include <hdlConvertor/vhdlConvertor/literalParser.h>
 #include <hdlConvertor/vhdlConvertor/referenceParser.h>
 
+#include <hdlConvertor/createObject.h>
+
 namespace hdlConvertor {
 namespace vhdl {
 
@@ -20,7 +22,6 @@ std::unique_ptr<HdlCompInstance> VhdlCompInstanceParser::visitComponent_instanti
 	// ;
 	auto ci = visitInstantiated_unit(ctx->instantiated_unit());
 	ci->name = iHdlExpr::ID(name);
-	ci->position.update_from_elem(ctx);
 
 	auto gma = ctx->generic_map_aspect();
 	if (gma) {
@@ -53,7 +54,7 @@ std::unique_ptr<HdlCompInstance> VhdlCompInstanceParser::visitInstantiated_unit(
 				"CompInstanceParser.visitInstantiated_unit - Identifier", _id);
 	}
 	auto ent_name = VhdlReferenceParser::visitName(ctx->name());
-	return std::make_unique<HdlCompInstance>(nullptr, std::move(ent_name));
+	return create_object<HdlCompInstance>(ctx, nullptr, std::move(ent_name));
 }
 
 std::unique_ptr<std::vector<std::unique_ptr<iHdlExpr>>> VhdlCompInstanceParser::visitGeneric_map_aspect(

--- a/src/vhdlConvertor/designFileParser.cpp
+++ b/src/vhdlConvertor/designFileParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/hdlObjects/hdlCall.h>
 #include <hdlConvertor/hdlObjects/hdlStm_others.h>
@@ -158,7 +159,7 @@ void VhdlDesignFileParser::visitUse_clause(vhdlParser::Use_clauseContext *ctx,
 		auto r = VhdlReferenceParser::visitSelected_name(sn);
 		std::vector<std::unique_ptr<iHdlExpr>> ref;
 		flatten_doted_expr(move(r), ref);
-		auto imp = std::make_unique<HdlStmImport>(ref);
+		auto imp = create_object<HdlStmImport>(sn, ref);
 		res.push_back(std::move(imp));
 
 	}

--- a/src/vhdlConvertor/entityParser.cpp
+++ b/src/vhdlConvertor/entityParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/hdlObjects/iHdlExpr.h>
 #include <hdlConvertor/vhdlConvertor/entityParser.h>
@@ -23,7 +24,7 @@ std::unique_ptr<HdlModuleDec> VhdlEntityParser::visitEntity_declaration(
 	//       ( KW_BEGIN ( entity_statement )* )?
 	//       KW_END ( KW_ENTITY )? ( identifier )? SEMI
 	// ;
-	auto e = std::make_unique<HdlModuleDec>();
+	auto e = create_object<HdlModuleDec>(ctx);
 	e->name = ctx->identifier(0)->getText();
 	e->__doc__ = commentParser.parse(ctx);
 
@@ -41,7 +42,6 @@ std::unique_ptr<HdlModuleDec> VhdlEntityParser::visitEntity_declaration(
 			NotImplementedLogger::print("EntityParser.entity_statement", ctx);
 		}
 	}
-	e->position.update_from_elem(ctx);
 	return e;
 }
 
@@ -101,7 +101,6 @@ void VhdlEntityParser::visitPort_clause(vhdlParser::Port_clauseContext *ctx,
 	for (auto ie : il->interface_element()) {
 		auto ps = VhdlInterfaceParser::visitInterface_element(ie);
 		for (auto &p : *ps) {
-			p->position.update_from_elem(ie);
 			ports.push_back(std::move(p));
 		}
 	}

--- a/src/vhdlConvertor/generateStatementParser.cpp
+++ b/src/vhdlConvertor/generateStatementParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 
 #include <hdlConvertor/hdlObjects/hdlStmFor.h>
@@ -66,14 +67,13 @@ std::unique_ptr<iHdlStatement> VhdlGenerateStatementParser::visitFor_generate_st
 	auto args = VhdlStatementParser::visitParameter_specification(
 			ctx->parameter_specification());
 	auto objs = visitGenerate_statement_body(ctx->generate_statement_body());
-	auto fstm = std::make_unique<HdlStmForIn>(move(args.first),
+	auto fstm = create_object<HdlStmForIn>(ctx, move(args.first),
 			move(args.second), move(objs));
 	auto label = ctx->label();
 	if (label) {
 		auto l = VhdlLiteralParser::visitLabel(label);
 		fstm->labels.push_back(l);
 	}
-	fstm->position.update_from_elem(ctx);
 	fstm->in_preproc = true;
 	return fstm;
 }
@@ -114,9 +114,8 @@ std::unique_ptr<HdlStmIf> VhdlGenerateStatementParser::visitIf_generate_statemen
 		ifFalse = visitGenerate_statement_body(*sIt);
 	}
 
-	ifStm = std::make_unique<HdlStmIf>(move(cond), move(ifTrue), elseIfs,
+	ifStm = create_object<HdlStmIf>(ctx, move(cond), move(ifTrue), elseIfs,
 			move(ifFalse));
-	ifStm->position.update_from_elem(ctx);
 	auto labels = ctx->label();
 	if (labels.size()) {
 		ifStm->labels.push_back(VhdlLiteralParser::visitLabel(labels[0]));
@@ -163,9 +162,8 @@ std::unique_ptr<HdlStmCase> VhdlGenerateStatementParser::visitCase_generate_stat
 			}
 		}
 	}
-	auto cstm = make_unique<HdlStmCase>(move(e), alternatives, move(_default));
+	auto cstm = create_object<HdlStmCase>(ctx, move(e), alternatives, move(_default));
 	cstm->in_preproc = true;
-	cstm->position.update_from_elem(ctx);
 	return cstm;
 }
 
@@ -179,7 +177,7 @@ std::unique_ptr<hdlObjects::HdlStmBlock> VhdlGenerateStatementParser::visitGener
 	//      )
 	//      | ( concurrent_statement )*
 	// ;
-	auto b = make_unique<HdlStmBlock>();
+	auto b = create_object<HdlStmBlock>(ctx);
 	auto bdis = ctx->block_declarative_item();
 	if (bdis.size()) {
 		VhdlBlockDeclarationParser _bdp(hierarchyOnly);

--- a/src/vhdlConvertor/interfaceParser.cpp
+++ b/src/vhdlConvertor/interfaceParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/vhdlConvertor/directionParser.h>
 #include <hdlConvertor/vhdlConvertor/exprParser.h>
@@ -39,7 +40,7 @@ std::unique_ptr<vector<std::unique_ptr<HdlVariableDef>>> VhdlInterfaceParser::ex
 		} else {
 			__expr = std::make_unique<iHdlExpr>(*expr);
 		}
-		auto v = std::make_unique<HdlVariableDef>(i->getText(),
+		auto v = create_object<HdlVariableDef>(i, i->getText(),
 				std::move(_type), std::move(__expr));
 		vl->push_back(std::move(v));
 	}

--- a/src/vhdlConvertor/packageHeaderParser.cpp
+++ b/src/vhdlConvertor/packageHeaderParser.cpp
@@ -14,6 +14,8 @@
 #include <hdlConvertor/vhdlConvertor/subtypeDeclarationParser.h>
 #include <hdlConvertor/vhdlConvertor/variableParser.h>
 
+#include <hdlConvertor/createObject.h>
+
 namespace hdlConvertor {
 namespace vhdl {
 
@@ -32,7 +34,7 @@ std::unique_ptr<HdlNamespace> VhdlPackageHeaderParser::visitPackage_declaration(
 	//           package_declarative_part
 	//       END ( PACKAGE )? ( identifier )? SEMI
 	// ;
-	ph = std::make_unique<HdlNamespace>();
+	ph = create_object<HdlNamespace>(ctx);
 	ph->defs_only = true;
 	NotImplementedLogger::print(
 			"PackageHeaderParser.visitPackage_declaration - package_header",
@@ -190,7 +192,7 @@ std::unique_ptr<HdlModuleDec> VhdlPackageHeaderParser::visitComponent_declaratio
 	//       END COMPONENT ( identifier )? SEMI
 	// ;
 
-	auto e = std::make_unique<HdlModuleDec>();
+	auto e = create_object<HdlModuleDec>(ctx);
 	e->name = ctx->identifier(0)->getText();
 	if (!hierarchyOnly) {
 		auto gc = ctx->generic_clause();

--- a/src/vhdlConvertor/packageParser.cpp
+++ b/src/vhdlConvertor/packageParser.cpp
@@ -19,6 +19,7 @@
 
 #include <hdlConvertor/vhdlConvertor/variableParser.h>
 
+#include <hdlConvertor/createObject.h>
 
 namespace hdlConvertor {
 namespace vhdl {
@@ -36,7 +37,7 @@ std::unique_ptr<HdlNamespace> VhdlPackageParser::visitPackage_body(
 	//           ( package_body_declarative_item )*
 	//       END ( PACKAGE BODY )? ( identifier )? SEMI
 	// ;
-	p = std::make_unique<HdlNamespace>();
+	p = create_object<HdlNamespace>(ctx);
 	p->name = VhdlLiteralParser::getIdentifierStr(ctx->identifier(0));
 
 	if (!hierarchyOnly) {

--- a/src/vhdlConvertor/processParser.cpp
+++ b/src/vhdlConvertor/processParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/vhdlConvertor/constantParser.h>
 #include <hdlConvertor/vhdlConvertor/literalParser.h>
@@ -24,9 +25,8 @@ std::unique_ptr<hdlObjects::HdlStmProcess> VhdlProcessParser::visitProcess_state
 	//               ( sequential_statement )*
 	//           KW_END ( KW_POSTPONED )? KW_PROCESS ( label )? SEMI
 	// ;
-	auto p = std::make_unique<HdlStmProcess>();
+	auto p = create_object<HdlStmProcess>(ctx);
 	auto &stms = dynamic_cast<HdlStmBlock*>(p->body.get())->statements;
-	p->position.update_from_elem(ctx);
 	auto sl = ctx->process_sensitivity_list();
 	if (sl) {
 		p->sensitivity_list = std::make_unique<

--- a/src/vhdlConvertor/subProgramDeclarationParser.cpp
+++ b/src/vhdlConvertor/subProgramDeclarationParser.cpp
@@ -1,3 +1,4 @@
+#include <hdlConvertor/createObject.h>
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/vhdlConvertor/exprParser.h>
 #include <hdlConvertor/vhdlConvertor/interfaceParser.h>
@@ -49,7 +50,7 @@ std::unique_ptr<hdlObjects::HdlFunctionDef> VhdlSubProgramDeclarationParser::vis
 	else
 		paramList = std::make_unique<
 				std::vector<std::unique_ptr<HdlVariableDef>>>();
-	return std::make_unique<HdlFunctionDef>(name, isOperator, nullptr,
+	return create_object<HdlFunctionDef>(ctx, name, isOperator, nullptr,
 			move(paramList));
 }
 
@@ -79,7 +80,7 @@ std::unique_ptr<hdlObjects::HdlFunctionDef> VhdlSubProgramDeclarationParser::vis
 	else
 		paramList = std::make_unique<
 				std::vector<std::unique_ptr<HdlVariableDef>>>();
-	return std::make_unique<HdlFunctionDef>(name, isOperator,
+	return create_object<HdlFunctionDef>(ctx, name, isOperator,
 			std::move(returnT), std::move(paramList));
 }
 

--- a/src/vhdlConvertor/subProgramParser.cpp
+++ b/src/vhdlConvertor/subProgramParser.cpp
@@ -5,6 +5,8 @@
 #include <hdlConvertor/vhdlConvertor/subProgramDeclarationParser.h>
 #include <hdlConvertor/vhdlConvertor/subProgramParser.h>
 
+#include <hdlConvertor/createObject.h>
+
 using namespace hdlConvertor::hdlObjects;
 using vhdlParser = vhdl_antlr::vhdlParser;
 
@@ -65,7 +67,7 @@ std::unique_ptr<HdlFunctionDef> VhdlSubProgramParser::visitProcedure_specificati
 	if (fpl)
 		paramList = visitFormal_parameter_list(fpl);
 
-	return std::make_unique<HdlFunctionDef>(name, isOperator, nullptr, std::move(paramList));
+	return create_object<HdlFunctionDef>(ctx, name, isOperator, nullptr, std::move(paramList));
 }
 
 std::unique_ptr<HdlFunctionDef> VhdlSubProgramParser::visitFunction_specification(
@@ -87,7 +89,7 @@ std::unique_ptr<HdlFunctionDef> VhdlSubProgramParser::visitFunction_specificatio
 	if (fpl)
 		paramList = visitFormal_parameter_list(fpl);
 
-	return std::make_unique<HdlFunctionDef>(name, isOperator, std::move(returnT),
+	return create_object<HdlFunctionDef>(ctx, name, isOperator, std::move(returnT),
 			std::move(paramList));
 }
 

--- a/src/vhdlConvertor/subtypeDeclarationParser.cpp
+++ b/src/vhdlConvertor/subtypeDeclarationParser.cpp
@@ -2,6 +2,8 @@
 #include <hdlConvertor/vhdlConvertor/subtypeDeclarationParser.h>
 #include <hdlConvertor/vhdlConvertor/literalParser.h>
 
+#include <hdlConvertor/createObject.h>
+
 using namespace hdlConvertor::hdlObjects;
 using vhdlParser = vhdl_antlr::vhdlParser;
 
@@ -14,7 +16,7 @@ std::unique_ptr<HdlVariableDef> VhdlSubtypeDeclarationParser::visitSubtype_decla
 	//  : SUBTYPE identifier IS subtype_indication SEMI
 	//  ;
 	auto t = VhdlExprParser::visitSubtype_indication(ctx->subtype_indication());
-	auto v = std::make_unique<HdlVariableDef>(
+	auto v = create_object<HdlVariableDef>(ctx,
 			VhdlLiteralParser::getIdentifierStr(ctx->identifier()),
 			iHdlExpr::TYPE_T(), std::move(t));
 	return v;


### PR DESCRIPTION
Create a generic virtual constructor to create all HDL objects and
reroute all constructor calls. The virtual constructor implements
some generic initialization logic (fill positional information, for
now),

Also, updated WithPos::update_from_elem to populate column
information.

Known Issues -
Current implementation of iHDLEpr, iHDLExprItem and subclasses
don't easily lend themselves to adding positional information.

Certain use case like ModuleDef::entityName are built from cached
string and so positional information is lost.
