### PR TITLE
(REJECT THIS) First cut at HdlLibrary addition for VHDL library clause, issue #102.

### DIFF
--- a/hdlConvertor/hdlAst/__init__.py
+++ b/hdlConvertor/hdlAst/__init__.py
@@ -25,6 +25,6 @@ from hdlConvertor.hdlAst._statements import (HdlImport, HdlStmAssign,
     HdlStmForIn, HdlStmIf, HdlStmProcess, HdlStmReturn, HdlStmWait,
     HdlStmWhile)
 from hdlConvertor.hdlAst._structural import (HdlComponentInst, HdlContext,
-    HdlModuleDec, HdlModuleDef, HdlNamespace)
+    HdlModuleDec, HdlModuleDef, HdlNamespace, HdlLibrary)
 from hdlConvertor.hdlAst._typeDefs import HdlClassDef, HdlEnumDef, HdlTypeBitsDef
 from hdlConvertor.hdlAst.utils import CodePosition

--- a/hdlConvertor/hdlAst/_structural.py
+++ b/hdlConvertor/hdlAst/_structural.py
@@ -4,6 +4,17 @@ from hdlConvertor.hdlAst._bases import iHdlObjWithName, iHdlObjInModule, iHdlObj
 from hdlConvertor.hdlAst._defs import HdlVariableDef
 
 
+class HdlLibrary(iHdlObjWithName):
+    """
+    The library clause in VHDL
+    """
+    __slots__ = []
+    #rhinton:: slots?
+
+    def __init__(self):
+        super(HdlLibrary, self).__init__()
+        
+
 class HdlNamespace(iHdlObjWithName):
     """
     Corresponds to VHDL package/package body or SystemVerilog namespace

--- a/hdlConvertor/toPy.cpp
+++ b/hdlConvertor/toPy.cpp
@@ -29,7 +29,7 @@ ToPy::ToPy() {
 		obj = PyObject_GetAttrString(hdlAst_module, name.c_str());
 		assert(
 				obj != NULL &&"Bug in this library hdlConvertor.hdlAst not as expected from C");
-};
+	};
 	import(ContextCls, "HdlContext");
 	import(CodePositionCls, "CodePosition");
 	import(HdlModuleDefCls, "HdlModuleDef");
@@ -56,6 +56,7 @@ ToPy::ToPy() {
 	import(HdlStmContinueCls, "HdlStmContinue");
 	import(HdlStmWaitCls, "HdlStmWait");
 	import(HdlStmBlockCls, "HdlStmBlock");
+	import(HdlLibraryCls, "HdlLibrary");
 	import(HdlImportCls, "HdlImport");
 	import(HdlComponentInstCls, "HdlComponentInst");
 	import(HdlFunctionDefCls, "HdlFunctionDef");
@@ -87,10 +88,23 @@ PyObject* ToPy::toPy(const HdlContext *o) {
 	return py_inst;
 }
 
+PyObject* ToPy::toPy(const HdlLibrary *o) {
+	PyObject *py_inst = PyObject_CallObject(HdlLibraryCls, NULL);
+	if (!py_inst)
+		return nullptr;
+	if (toPy_property(py_inst, "name", o->name))
+		//rhinton:: Is this done automatically by ToPy(WithNameAndDoc*, PyObject*)?
+		return nullptr;
+	return py_inst;
+}
+
 PyObject* ToPy::toPy(const iHdlObj *o) {
 	auto c = dynamic_cast<const HdlContext*>(o);
 	if (c)
 		return toPy(c);
+	auto lib = dynamic_cast<const HdlLibrary*>(o);
+	if (lib)
+		return toPy(lib);
 	auto md = dynamic_cast<const HdlModuleDec*>(o);
 	if (md)
 		return toPy(md);
@@ -441,6 +455,7 @@ ToPy::~ToPy() {
 	Py_XDECREF(HdlNamespaceCls);
 	Py_XDECREF(HdlFunctionDefCls);
 	Py_XDECREF(HdlComponentInstCls);
+	Py_XDECREF(HdlLibraryCls);
 	Py_XDECREF(HdlImportCls);
 	Py_XDECREF(HdlStmBlockCls);
 	Py_XDECREF(HdlStmWaitCls);

--- a/hdlConvertor/toPy.h
+++ b/hdlConvertor/toPy.h
@@ -5,11 +5,11 @@
 
 #include <hdlConvertor/hdlObjects/hdlCompInstance.h>
 #include <hdlConvertor/hdlObjects/hdlContext.h>
+#include <hdlConvertor/hdlObjects/hdlLibrary.h>
 #include <hdlConvertor/hdlObjects/iHdlExpr.h>
 #include <hdlConvertor/hdlObjects/named.h>
 #include <hdlConvertor/hdlObjects/hdlCall.h>
 #include <hdlConvertor/hdlObjects/hdlOperatorType.h>
-#include <hdlConvertor/hdlObjects/hdlNamespace.h>
 #include <hdlConvertor/hdlObjects/hdlNamespace.h>
 #include <hdlConvertor/hdlObjects/hdlModuleDec.h>
 #include <hdlConvertor/hdlObjects/hdlModuleDef.h>
@@ -57,6 +57,7 @@ class ToPy {
 	PyObject *HdlStmWaitCls;
 	PyObject *HdlStmBlockCls;
 	PyObject *HdlImportCls;
+	PyObject *HdlLibraryCls;
 	PyObject *HdlComponentInstCls;
 	PyObject *HdlFunctionDefCls;
 	PyObject *HdlNamespaceCls;
@@ -145,6 +146,7 @@ public:
 	PyObject* toPy(const hdlObjects::HdlModuleDef *o);
 	PyObject* toPy(const hdlObjects::HdlCompInstance *o);
 	PyObject* toPy(const hdlObjects::HdlContext *o);
+	PyObject* toPy(const hdlObjects::HdlLibrary *o);
 	PyObject* toPy(const hdlObjects::HdlDirection o);
 	PyObject* toPy(const hdlObjects::HdlModuleDec *o);
 	PyObject* toPy(const hdlObjects::iHdlExpr *o);

--- a/hdlConvertor/toVhdl.py
+++ b/hdlConvertor/toVhdl.py
@@ -4,7 +4,7 @@ from hdlConvertor.hdlAst import HdlDirection, HdlBuiltinFn, HdlName,\
     HdlIntValue, HdlAll, HdlCall, HdlOthers, iHdlStatement, HdlStmProcess,\
     HdlStmIf, HdlStmAssign, HdlStmCase, HdlStmWait, HdlStmReturn, HdlStmFor, \
     HdlVariableDef, HdlModuleDec, HdlFunctionDef, HdlComponentInst,\
-    HdlModuleDef, HdlNamespace, HdlImport
+    HdlModuleDef, HdlNamespace, HdlImport, HdlLibrary
 from hdlConvertor.hdlAst._statements import HdlStmBlock
 
 
@@ -190,11 +190,12 @@ class ToVhdl():
             w(f.format(v))
 
             return
-        elif isinstance(expr, HdlName):
-            w(v)
+        elif expr is HdlAll:  # one previous line had 'elif isinstance(expr, HdlAll)'
+            #w("*") #rhinton:: maybe this is the Verilog syntax?
+            w("ALL")
             return
-        elif isinstance(expr, HdlAll):
-            w("*")
+        elif expr is HdlOthers:
+            w("OTHERS")
             return
         elif isinstance(expr, HdlCall):
             pe = self.print_expr
@@ -287,9 +288,6 @@ class ToVhdl():
                 return
             else:
                 raise NotImplementedError(op)
-        elif expr is HdlAll:
-            w("ALL")
-            return
         elif isinstance(expr, list):
             w("(\n")
             with Indent(self.out):
@@ -298,12 +296,6 @@ class ToVhdl():
                     if not is_last:
                         w(",\n")
             w(")")
-            return
-        elif expr is HdlAll:
-            w("ALL")
-            return
-        elif expr is HdlOthers:
-            w("OTHERS")
             return
         raise NotImplementedError(expr)
 
@@ -644,9 +636,12 @@ class ToVhdl():
         w("END FUNCTION;\n")
 
     def print_library(self, o):
+        lib_name = o.name
+        self.used_libraries.add(lib_name)
         w = self.out.write
         w("LIBRARY ")
-        self.print_expr(o)
+        #self.print_expr(o) #rhinton:: currently not storing a full expression, just a bare string for the name
+        w(lib_name)
         w(";\n")
 
     def print_hdl_import(self, o):
@@ -656,9 +651,12 @@ class ToVhdl():
         self.print_doc(o)
         w = self.out.write
         lib_name = o.path[0]
+        #rhinton:: conversion from Verilog probably doesn't create an explicit
+        # library declaration yet
         if lib_name not in self.used_libraries:
-            self.print_library(lib_name)
-            self.used_libraries.add(lib_name)
+            lib = HdlLibrary()
+            lib.name = lib_name
+            self.print_library(lib)
 
         w("USE ")
         for last, p in iter_with_last_flag(o.path):
@@ -707,6 +705,8 @@ class ToVhdl():
         for o in context.objs:
             if isinstance(o, HdlImport):
                 self.print_hdl_import(o)
+            elif isinstance(o, HdlLibrary):
+                self.print_library(o)
             else:
                 self.print_main_obj(o)
 

--- a/include/hdlConvertor/hdlObjects/hdlLibrary.h
+++ b/include/hdlConvertor/hdlObjects/hdlLibrary.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <hdlConvertor/hdlObjects/named.h>
+#include <hdlConvertor/hdlObjects/iHdlObj.h>
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+/*
+ * HDL library reference
+ * */
+class HdlLibrary : public WithNameAndDoc, public iHdlObj {
+public:
+	//rhinton:: Although the grammar allows for a list of library 
+	// names in a single library clause, it seems simpler to define
+	// the hdlLibrary object with a single name.  If several library 
+	// names are packed into a single library clause, the result will 
+	// be one hdlLibrary object per name.
+	HdlLibrary(const std::string& name);
+	~HdlLibrary();
+};
+
+}
+}

--- a/include/hdlConvertor/vhdlConvertor/designFileParser.h
+++ b/include/hdlConvertor/vhdlConvertor/designFileParser.h
@@ -26,6 +26,7 @@ public:
 	void visitContext_clause(vhdlParser::Context_clauseContext *ctx);
 	void visitPrimary_unit(vhdlParser::Primary_unitContext *ctx);
 	void visitContext_item(vhdlParser::Context_itemContext *ctx);
+        void visitLibrary_clause(vhdlParser::Library_clauseContext *ctx);
 	void visitUse_clause(vhdlParser::Use_clauseContext *ctx,
 			std::vector<std::unique_ptr<hdlObjects::iHdlObj>> &res);
 };

--- a/src/hdlObjects/hdlLibrary.cpp
+++ b/src/hdlObjects/hdlLibrary.cpp
@@ -1,0 +1,14 @@
+#include <hdlConvertor/hdlObjects/hdlLibrary.h>
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+HdlLibrary::HdlLibrary(const std::string& name) :
+		WithNameAndDoc(name), iHdlObj() {
+}
+    
+HdlLibrary::~HdlLibrary() {
+}
+
+}
+}


### PR DESCRIPTION
Please reject this pull request after examining my work in progress.  I have several questions, comments, and concerns still in the code in a comment that begins "rhinton::", e.g. in C++ it will be "//rhinton:: ...".  Would you like me to echo these comments and such here in this conversation?

I have a simple test that passes.  I see you have some VHDL tests, but it appears that they test simply that a file parses without testing any of the *results* of the parse.  Testing the library clause code requires testing the contents.

Comments are very welcome.