### PR TITLE
(#102) Add HdlLibrary object and its VHDL parsing

### DIFF
--- a/hdlConvertor/hdlAst/__init__.py
+++ b/hdlConvertor/hdlAst/__init__.py
@@ -25,6 +25,6 @@ from hdlConvertor.hdlAst._statements import (HdlImport, HdlStmAssign,
     HdlStmForIn, HdlStmIf, HdlStmProcess, HdlStmReturn, HdlStmWait,
     HdlStmWhile)
 from hdlConvertor.hdlAst._structural import (HdlComponentInst, HdlContext,
-    HdlModuleDec, HdlModuleDef, HdlNamespace)
+    HdlModuleDec, HdlModuleDef, HdlNamespace, HdlLibrary)
 from hdlConvertor.hdlAst._typeDefs import HdlClassDef, HdlEnumDef, HdlTypeBitsDef
 from hdlConvertor.hdlAst.utils import CodePosition

--- a/hdlConvertor/hdlAst/_structural.py
+++ b/hdlConvertor/hdlAst/_structural.py
@@ -4,6 +4,16 @@ from hdlConvertor.hdlAst._bases import iHdlObjWithName, iHdlObjInModule, iHdlObj
 from hdlConvertor.hdlAst._defs import HdlVariableDef
 
 
+class HdlLibrary(iHdlObjWithName):
+    """
+    The library clause in VHDL
+    """
+    __slots__ = []
+
+    def __init__(self):
+        super(HdlLibrary, self).__init__()
+        
+
 class HdlNamespace(iHdlObjWithName):
     """
     Corresponds to VHDL package/package body or SystemVerilog namespace

--- a/hdlConvertor/toPy.cpp
+++ b/hdlConvertor/toPy.cpp
@@ -29,7 +29,7 @@ ToPy::ToPy() {
 		obj = PyObject_GetAttrString(hdlAst_module, name.c_str());
 		assert(
 				obj != NULL &&"Bug in this library hdlConvertor.hdlAst not as expected from C");
-};
+	};
 	import(ContextCls, "HdlContext");
 	import(CodePositionCls, "CodePosition");
 	import(HdlModuleDefCls, "HdlModuleDef");
@@ -56,6 +56,7 @@ ToPy::ToPy() {
 	import(HdlStmContinueCls, "HdlStmContinue");
 	import(HdlStmWaitCls, "HdlStmWait");
 	import(HdlStmBlockCls, "HdlStmBlock");
+	import(HdlLibraryCls, "HdlLibrary");
 	import(HdlImportCls, "HdlImport");
 	import(HdlComponentInstCls, "HdlComponentInst");
 	import(HdlFunctionDefCls, "HdlFunctionDef");
@@ -87,10 +88,22 @@ PyObject* ToPy::toPy(const HdlContext *o) {
 	return py_inst;
 }
 
+PyObject* ToPy::toPy(const HdlLibrary *o) {
+	PyObject *py_inst = PyObject_CallObject(HdlLibraryCls, NULL);
+	if (!py_inst)
+		return nullptr;
+	if (toPy(static_cast<const WithNameAndDoc*>(o), py_inst))
+		return nullptr;
+	return py_inst;
+}
+
 PyObject* ToPy::toPy(const iHdlObj *o) {
 	auto c = dynamic_cast<const HdlContext*>(o);
 	if (c)
 		return toPy(c);
+	auto lib = dynamic_cast<const HdlLibrary*>(o);
+	if (lib)
+		return toPy(lib);
 	auto md = dynamic_cast<const HdlModuleDec*>(o);
 	if (md)
 		return toPy(md);
@@ -442,6 +455,7 @@ ToPy::~ToPy() {
 	Py_XDECREF(HdlFunctionDefCls);
 	Py_XDECREF(HdlComponentInstCls);
 	Py_XDECREF(HdlImportCls);
+	Py_XDECREF(HdlLibraryCls);
 	Py_XDECREF(HdlStmBlockCls);
 	Py_XDECREF(HdlStmWaitCls);
 	Py_XDECREF(HdlStmContinueCls);

--- a/hdlConvertor/toPy.h
+++ b/hdlConvertor/toPy.h
@@ -5,11 +5,11 @@
 
 #include <hdlConvertor/hdlObjects/hdlCompInstance.h>
 #include <hdlConvertor/hdlObjects/hdlContext.h>
+#include <hdlConvertor/hdlObjects/hdlLibrary.h>
 #include <hdlConvertor/hdlObjects/iHdlExpr.h>
 #include <hdlConvertor/hdlObjects/named.h>
 #include <hdlConvertor/hdlObjects/hdlCall.h>
 #include <hdlConvertor/hdlObjects/hdlOperatorType.h>
-#include <hdlConvertor/hdlObjects/hdlNamespace.h>
 #include <hdlConvertor/hdlObjects/hdlNamespace.h>
 #include <hdlConvertor/hdlObjects/hdlModuleDec.h>
 #include <hdlConvertor/hdlObjects/hdlModuleDef.h>
@@ -57,6 +57,7 @@ class ToPy {
 	PyObject *HdlStmWaitCls;
 	PyObject *HdlStmBlockCls;
 	PyObject *HdlImportCls;
+	PyObject *HdlLibraryCls;
 	PyObject *HdlComponentInstCls;
 	PyObject *HdlFunctionDefCls;
 	PyObject *HdlNamespaceCls;
@@ -145,6 +146,7 @@ public:
 	PyObject* toPy(const hdlObjects::HdlModuleDef *o);
 	PyObject* toPy(const hdlObjects::HdlCompInstance *o);
 	PyObject* toPy(const hdlObjects::HdlContext *o);
+	PyObject* toPy(const hdlObjects::HdlLibrary *o);
 	PyObject* toPy(const hdlObjects::HdlDirection o);
 	PyObject* toPy(const hdlObjects::HdlModuleDec *o);
 	PyObject* toPy(const hdlObjects::iHdlExpr *o);

--- a/include/hdlConvertor/hdlObjects/hdlLibrary.h
+++ b/include/hdlConvertor/hdlObjects/hdlLibrary.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <hdlConvertor/hdlObjects/named.h>
+#include <hdlConvertor/hdlObjects/iHdlObj.h>
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+/*
+ * HDL library reference
+ * */
+class HdlLibrary : public WithNameAndDoc, public iHdlObj {
+public:
+	HdlLibrary(const std::string& name);
+	~HdlLibrary();
+};
+
+}
+}

--- a/include/hdlConvertor/vhdlConvertor/designFileParser.h
+++ b/include/hdlConvertor/vhdlConvertor/designFileParser.h
@@ -26,6 +26,7 @@ public:
 	void visitContext_clause(vhdlParser::Context_clauseContext *ctx);
 	void visitPrimary_unit(vhdlParser::Primary_unitContext *ctx);
 	void visitContext_item(vhdlParser::Context_itemContext *ctx);
+        void visitLibrary_clause(vhdlParser::Library_clauseContext *ctx);
 	void visitUse_clause(vhdlParser::Use_clauseContext *ctx,
 			std::vector<std::unique_ptr<hdlObjects::iHdlObj>> &res);
 };

--- a/src/hdlObjects/hdlLibrary.cpp
+++ b/src/hdlObjects/hdlLibrary.cpp
@@ -1,0 +1,14 @@
+#include <hdlConvertor/hdlObjects/hdlLibrary.h>
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+HdlLibrary::HdlLibrary(const std::string& name) :
+		WithNameAndDoc(name), iHdlObj() {
+}
+    
+HdlLibrary::~HdlLibrary() {
+}
+
+}
+}

--- a/src/vhdlConvertor/designFileParser.cpp
+++ b/src/vhdlConvertor/designFileParser.cpp
@@ -2,6 +2,7 @@
 #include <hdlConvertor/notImplementedLogger.h>
 #include <hdlConvertor/hdlObjects/hdlCall.h>
 #include <hdlConvertor/hdlObjects/hdlStm_others.h>
+#include <hdlConvertor/hdlObjects/hdlLibrary.h>
 #include <hdlConvertor/vhdlConvertor/archParser.h>
 #include <hdlConvertor/vhdlConvertor/designFileParser.h>
 #include <hdlConvertor/vhdlConvertor/entityParser.h>
@@ -124,13 +125,27 @@ void VhdlDesignFileParser::visitContext_item(
 	// ;
 	auto l = ctx->library_clause();
 	if (l) {
-		NotImplementedLogger::print(
-				"DesignFileParser.visitContext_item - library_clause", l);
-		return; //libraries are ignored
+		visitLibrary_clause(l);
 	}
 	auto u = ctx->use_clause();
 	if (u) {
 		visitUse_clause(u, context.objs);
+	}
+}
+
+void VhdlDesignFileParser::visitLibrary_clause(
+		vhdlParser::Library_clauseContext *ctx) {
+	// library_clause: KW_LIBRARY logical_name_list SEMI;
+	// logical_name_list: identifier_list;
+	vhdlParser::Logical_name_listContext *lnl_ctx = ctx->logical_name_list();
+	if (lnl_ctx) {
+		vhdlParser::Identifier_listContext *il_ctx = lnl_ctx->identifier_list();
+		if (il_ctx) {
+			for (auto i : il_ctx->identifier()) {
+				auto v = create_object<HdlLibrary>(i, i->getText());
+				context.objs.push_back(std::move(v));
+			}
+		}
 	}
 }
 
@@ -161,7 +176,6 @@ void VhdlDesignFileParser::visitUse_clause(vhdlParser::Use_clauseContext *ctx,
 		flatten_doted_expr(move(r), ref);
 		auto imp = create_object<HdlStmImport>(sn, ref);
 		res.push_back(std::move(imp));
-
 	}
 }
 

--- a/tests/test_vhdl_conversion.py
+++ b/tests/test_vhdl_conversion.py
@@ -55,6 +55,12 @@ class VhdlConversionTC(BasicTC):
     def test_type_attribute_designator(self):
         self.parseWithRef("type_attribute_designator.vhd", Language.VHDL)
 
+    def test_library_declaration(self):
+        f, res = parseFile("ram.vhd")
+        self.assertEqual(str(type(res.objs[0])),
+                          "<class 'hdlConvertor.hdlAst._structural.HdlLibrary'>")
+        self.assertEqual(res.objs[0].name, 'ieee')
+
 
 if __name__ == "__main__":
     suite = unittest.TestSuite()

--- a/tests/vhdl/expected/ram.vhd
+++ b/tests/vhdl/expected/ram.vhd
@@ -1,3 +1,5 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
 
 -- https://surf-vhdl.com/vhdl-syntax-web-course-surf-vhdl/vhdl-generics/
 ENTITY RAM IS

--- a/tests/vhdl/ram.vhd
+++ b/tests/vhdl/ram.vhd
@@ -1,3 +1,5 @@
+library ieee;
+use ieee.std_logic_1164.all;
 -- https://surf-vhdl.com/vhdl-syntax-web-course-surf-vhdl/vhdl-generics/
 entity RAM is
 generic(


### PR DESCRIPTION
Add an HdlLibrary C++ object to represent a VHDL library declaration.
Add the parsing logic to create this object from a VHDL library clause.

Add a corresponding Python object and code to convert to and from the
Python AST.  Also reworked the Python around the VHDL 'use' clause
emission to eliminate "auto" library emission.  Since the library
object is now explicit, it should be created in the AST for it to
appear in the VHDL output.