### PR TITLE
WIP Add C++ classes for common data type declarations (issue #107)

### DIFF
--- a/include/hdlConvertor/hdlObjects/hdlTypeDec.h
+++ b/include/hdlConvertor/hdlObjects/hdlTypeDec.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <hdlConvertor/hdlObjects/named.h>
+#include <hdlConvertor/hdlObjects/iHdlObj.h>
+
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+/*
+ * HDL AST node for module declaration
+ * (part with ports and params for Verilog, Entity for VHDL)
+ * */
+class HdlTypeDec: public WithNameAndDoc, public iHdlObj {
+public:
+	enum TypeClass {hdltc_error, hdltc_enum, hdltc_array, hdltc_struct, 
+		hdltc_physical, hdltc_integral, hdltc_float};
+	HdlTypeDec(const std::string& name);
+	virtual TypeClass typeClass() = 0;
+	virtual ~HdlTypeDec();
+};
+
+class HdlEnumTypeDec: public HdlTypeDec {
+public:
+	std::vector<std::string> ids;
+	//std::vector<std::unique_ptr<iHdlExpr>> path;
+	//
+	//rhinton: may need iHdlExpr to handle VHDL character literal vs. identifier
+	//
+	//rhinton: does SystemVerilog associate values to enums like C does?  If so, we'll need to store (optional?) values here as well
+
+	//HdlEnumTypeDec();
+	TypeClass typeClass() override;
+	virtual ~HdlEnumTypeDec();
+};
+
+class HdlArrayTypeDec: public HdlTypeDec {
+public:
+	std::vector<std::unique_ptr<iHdlExpr>> indexes;
+	std::unique_ptr<iHdlExpr> element;
+
+	//HdlArrayTypeDec();
+	TypeClass typeClass() override;
+	virtual ~HdlArrayTypeDec();
+};
+
+class HdlStructTypeDec: public HdlTypeDec {
+public:
+	std::vector<std::unique_ptr<HdlVariableDef>> fields;
+
+	//HdlStructTypeDec();
+	TypeClass typeClass() override;
+	virtual ~HdlStructTypeDec();
+};
+
+
+
+}
+}

--- a/src/hdlObjects/hdlTypeDec.cpp
+++ b/src/hdlObjects/hdlTypeDec.cpp
@@ -1,0 +1,40 @@
+#include <hdlConvertor/hdlObjects/hdlTypeDec.h>
+
+namespace hdlConvertor {
+namespace hdlObjects {
+
+// type declaration base class
+HdlTypeDec::HdlTypeDec(const std::string& name) :
+		WithNameAndDoc(name), iHdlObj() {
+}
+    
+HdlTypeDec::~HdlTypeDec() {
+}
+
+// enumerated type
+HdlEnumTypeDec::~HdlEnumTypeDec() {
+}
+
+HdlTypeDec::TypeClass HdlEnumTypeDec::typeClass() {
+	return hdltc_enum;
+}
+
+// array type
+HdlArrayTypeDec::~HdlArrayTypeDec() {
+}
+
+HdlTypeDec::TypeClass HdlArrayTypeDec::typeClass() {
+	return hdltc_array;
+}
+
+// struct or record type
+HdlStructTypeDec::~HdlStructTypeDec() {
+}
+
+HdlTypeDec::TypeClass HdlStructTypeDec::typeClass() {
+	return hdltc_struct;
+}
+
+
+}
+}


### PR DESCRIPTION
This initial pull request is a work in progress and will probably be deleted/rejected/whatever.  Currently this commit is based on the upstream `master` branch, so it will conflict with the package parsing pull request (which should be merged instead of this one).

The goal of this pull request is to implement VHDL parsing for common type declarations.

The first step is to create a set of C++ classes to represent common data types.