### PR TITLE
A branch for testing generate-for

### DIFF
--- a/tests/test_verilog_conversion.py
+++ b/tests/test_verilog_conversion.py
@@ -5,7 +5,7 @@ from hdlConvertor import HdlConvertor
 from hdlConvertorAst.hdlAst import HdlModuleDec, HdlModuleDef, HdlDirection
 from hdlConvertorAst.language import Language
 
-from tests.hdl_parse_tc import TEST_DIR, HdlParseTC, parseFile
+from hdl_parse_tc import TEST_DIR, HdlParseTC, parseFile
 
 VERILOG = Language.VERILOG
 SV = Language.SYSTEM_VERILOG

--- a/tests/verilog/generate_for.v
+++ b/tests/verilog/generate_for.v
@@ -1,10 +1,26 @@
 module top();
   wire[2:0] out;
+  wire[2:0] out1;
+  wire[2:0] out2;
   genvar i;
 
   generate
     for(i=0;i<3;i=i+1)
       assign  out[i]=i;
+  endgenerate
+
+  generate
+    for(i=0;i<3;i=i+1)
+      begin
+        assign  out1[i]=i;
+      end
+  endgenerate
+
+  generate
+    for(i=0;i<3;i=i+1)
+      begin:test1
+        assign  out2[i]=i;
+      end
   endgenerate
 
 endmodule


### PR DESCRIPTION
1. solve an issue #124
2. add more generate-for test cases for issue #122 and the test cases will cause a error showing below

```
generate for (i = 0; i < 3; i = i + 1) **generate** begin: test1
    assign out2[i] = i;
end
endgenerate
```