### PR TITLE
Fix minor test errors

### DIFF
--- a/tests/verilog/aFifo.v
+++ b/tests/verilog/aFifo.v
@@ -10,8 +10,6 @@
 //            Xilinx website. It has some minor modifications.
 //=========================================
 
-`timescale 1ns/1ps
-
 module aFifo
   #(parameter    DATA_WIDTH    = 8,
                  ADDRESS_WIDTH = 4,

--- a/tests/verilog/aes.v
+++ b/tests/verilog/aes.v
@@ -55,8 +55,6 @@
 //
 //
 
-`include "timescale.v"
-
 module aes_cipher_top(clk, rst, ld, done, key, text_in, text_out );
 input		clk, rst;
 input		ld;

--- a/tests/verilog/parity_using_function2.v
+++ b/tests/verilog/parity_using_function2.v
@@ -12,7 +12,7 @@ parity_out   //  1 bit parity out
 output  parity_out ;
 input [7:0] data_in ;
 
-wire parity_out ;
+reg parity_out ;
 function parity;
   input [31:0] data;
   integer i;


### PR DESCRIPTION
This fixes two minor classes of problems causing failures on hdlConvertor imported running on Verilator as imported by https://symbiflow.github.io/sv-tests/ 

1. `timescale is illegal unless on every module and as the sv-tests adds another module this causes an error.
2. parity_using_function2 was using a reg as a wire.

If changing any of these fails your golden tests I'd appreciate if you'd update for me, thanks!