### PR TITLE
Fix syntax error

### DIFF
--- a/tests/verilog/expected/aes.v
+++ b/tests/verilog/expected/aes.v
@@ -165,7 +165,7 @@ module aes_cipher_top (
         else if (|dcnt)
             dcnt <= #1 dcnt - 4'h1;
     always @(posedge clk)
-        done <= #1 !|dcnt[3:1] & dcnt[0] & !ld;
+        done <= #1 !(|dcnt[3:1]) & dcnt[0] & !ld;
     always @(posedge clk)
         if (ld)
             text_in_r <= #1 text_in;

--- a/tests/verilog/expected/parity_using_function2.v
+++ b/tests/verilog/expected/parity_using_function2.v
@@ -10,8 +10,8 @@ module parity_using_function2 (
     // 8 bit data in
     output reg parity_out
 );
-    function wire parity (
-        input wire[31:0] data
+    function parity (
+        input [31:0] data
     );
         integer i;
         begin


### PR DESCRIPTION
In my understanding, 

* unary operators can't be concatenated directly and `()` is required.
* function can't take net_type.