### PR TITLE
Debug Build Documentation Update

### DIFF
--- a/doc/dev_minitutorial.md
+++ b/doc/dev_minitutorial.md
@@ -1,5 +1,27 @@
 # Tutorial for developing of C++ python extension with Cython and Scikit-build
 
+# Building a Debug Version of C++ python extension as a the pip package
+
+1. Create a Python Virtual Env.:
+
+   ```sh
+   python -m venv hdlConvertorVenv
+   ```
+
+2. Activate the virtual env and install `scikit-build`:
+   ```sh
+   . ./hdlConvertorVenv/bin/activate
+   pip install scikit-build
+   ```
+3. Use Python `setup.py` build to trigger a debug build:
+   ```sh
+   python setup.py build --build-type Debug -v
+   ```
+4. Installed the Debug version of C++ Extension:
+   ```sh
+   python setup.py install --build-type Debug -v
+   ```
+
 # Test execution
 
 In order to run tests you need to have all dependencies installed or appended in python path so python can import it.

--- a/doc/dev_minitutorial.md
+++ b/doc/dev_minitutorial.md
@@ -14,15 +14,38 @@
    cd hdlConvertor
    pip install -r requirements.txt
    ```
-3. Use Python `setup.py` build to trigger a debug build:
+
+3. Setup Debug Configuration for `sciki-build`:
    ```sh
-   python setup.py build --build-type Debug -v
+   export SKBUILD_CONFIGURE_OPTIONS="-DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
    ```
-4. Installed the Debug version of C++ Extension:
+   For ANTLR4 custom build installation configuration:
    ```sh
-   python setup.py install --build-type Debug -v
+   # Add Configuration from above if building in Debug Mode
+   export SKBUILD_CONFIGURE_OPTIONS="-DANTLR4CPP_ROOT=<Path to antlr4-cpp-runtime build/installation> ..."
+   export ANTLR_COMPLETE_PATH=<Absolute path to the directory where antlr4-complete.jar exists>
+   # e.g.:
+   # export SKBUILD_CONFIGURE_OPTIONS="-DANTLR4CPP_ROOT=/opt/antlr4/antlr4-cpp-runtime"
+   # export ANTLR_COMPLETE_PATH="/opt/antlr4"
+
+   ## The above path should have the 'antlr4-complete.jar' available at that directory.
+   # Also if the ANTLR4 Cpp Runtime is custom build one might need to add the library path to 'LD_LIBRARY_PATH'
+   ## e.g.:
+   ## export LD_LIBRARY_PATH=/opt/antlr4/antlr4-cpp-runtime/lib:$LD_LIBRARY_PATH
+   ```
+4. Use Python `pip` build and install the package in edit mode:
+   ```sh
+   # Use Python VirtualEnv for installation.
+   python -m pip install -e .
    ```
 
+5. Optional Step if you are also developing for `hdlConvertorAst` install the package locally as editable version of the package:
+   ```sh
+   # Use the same virtualenv for both of these packages
+   git clone https://github.com/Nic30/hdlConvertorAst
+   cd hdlConvertorAst
+   pip install -e .
+   ```
 # Test execution
 
 In order to run tests you need to have all dependencies installed or appended in python path so python can import it.

--- a/doc/dev_minitutorial.md
+++ b/doc/dev_minitutorial.md
@@ -8,10 +8,11 @@
    python -m venv hdlConvertorVenv
    ```
 
-2. Activate the virtual env and install `scikit-build`:
+2. Activate the virtual env and install `scikit-build` and `CPython` using [requirements.txt](https://github.com/Nic30/hdlConvertor/blob/master/requirements.txt) from the base repo path:
    ```sh
    . ./hdlConvertorVenv/bin/activate
-   pip install scikit-build
+   cd hdlConvertor
+   pip install -r requirements.txt
    ```
 3. Use Python `setup.py` build to trigger a debug build:
    ```sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Add documentation on setting up a Debug Development environment using venv(virtualenv)
Updated deprecated description-file to description_file. (warning encountered while running `python setup.py`)