### PR TITLE
tests+verilog preproc: Fix ANTLR <=4.9, CMake and Icarus tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@
 # build of the main library
 ##############################################################################################
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake_antlr4.txt)
 
 include_directories(

--- a/src/verilogPreproc/verilogPreproc.cpp
+++ b/src/verilogPreproc/verilogPreproc.cpp
@@ -1,3 +1,5 @@
+#include <any>
+
 #include <hdlConvertor/verilogPreproc/verilogPreproc.h>
 
 // antlr4-runtime/
@@ -194,7 +196,7 @@ antlrcpp::Any VerilogPreproc::visitDefine(
 	vector<MacroDefVerilog::param_info_t> params_dummy;
 	if (da) {
 #if !defined(ANTLRCPP_VERSION_MAJOR) || (ANTLRCPP_VERSION_MAJOR == 4 && ANTLRCPP_VERSION_MINOR <= 9)
-		params = visitDefine_args(da);
+		params = visitDefine_args(da).as<vector<MacroDefVerilog::param_info_t> *>();
 #else
 		params = std::any_cast<vector<MacroDefVerilog::param_info_t> *>(visitDefine_args(da));
 #endif

--- a/tests/test_icarus_verilog_testsuite.py
+++ b/tests/test_icarus_verilog_testsuite.py
@@ -48,6 +48,7 @@ def parse_verilator_record(line, dir_name):
         "sv_string_index": "string_index",
         "sv_timeunit_prec": "sv_timeunit_prec1",
         "sv_timeunit_prec_fail": "sv_timeunit_prec_fail1",
+        "sv_macro3": "sv_macro3a"
     }
     name = name_fix.get(name, name)
     args = columns[1]


### PR DESCRIPTION
- ANTLR 4.9 antlrcpp::Any was used incorrectly, preventing it from compiling on e.g. 4.9.3
- Depending on the compiler and CMake version used, C++ 17 wouldn't be automatically selected for the project.
- Icarus moved the test file "sv_macro3" to two separate versions (a and b), but this is not yet correctly reflected in their file lists. With this change, all ~7000 tests collect correctly again under pytest and concurrencytest.