### PR TITLE
GitHub CI with Prebuilt Binary Wheel

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Python Package
+name: Test, Build and Deploy
 
 on: [push]
 
@@ -6,7 +6,60 @@ permissions:
   contents: read
 
 jobs:
-  build_linux_amd64:
+  # Create a Debug build and test it.
+  build_and_test:
+    runs-on: ubuntu-20.04
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    # Don't need to install Python / Create venv, as you are running in a container.
+    # You don't even need to install g++/cmake as it comes with the docker image.
+    - name: Install Dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install build-essential uuid-dev cmake default-jre \
+                libantlr4-runtime-dev antlr4 libssl-dev -yq
+        pip install setuptools wheel cmake ninja patchelf auditwheel
+        pip install -r requirements.txt
+    
+    - name: Check Your Environment
+      run: |
+        gcc -v
+        python --version
+        cmake --version
+        free
+    
+    - name: Build
+      run: |
+        echo Your Build Script here
+        echo Make sure the Debug and Coverage Switch is on, only in this job.
+
+    - name: Test
+      run: |
+        echo Your Test Script here
+
+    - name: Extract Coverage Report
+      run: |
+        echo Your Coverage Report
+
+
+  # Build on Different Platform.
+    build_linux_amd64:
+    
+    # This can be expensive so you might skip this if it is not tagged
+    # by uncommenting the following
+    # if: ${{ startsWith(github.ref, 'refs/tags/v') && success() }}
+    
+    # Run only when the test is good.
+    if: ${{ success() }}
+
+    need:
+      - build_and_test
+
     strategy:
         matrix:
           python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
@@ -30,7 +83,11 @@ jobs:
     - name: Adding ANTLR4 License
       run: |
         curl -s https://raw.githubusercontent.com/antlr/antlr4/master/LICENSE.txt >> LICENSE
-    
+
+    # Build the library.
+    # Don't include debug and coverage stuff here.
+    # GitHub runner on Open source project is equipped with 4 cores. 
+    # Use them with `-j 4` flag
     - name: Build Library
       run: |
         python setup.py bdist_wheel -j 4
@@ -42,9 +99,17 @@ jobs:
         name: PythonPackage
         path: |
           wheelhouse
-  
+
+  # Build the Source Bundle
+  # Developer can still build on their machine with the source bundle
+  # (i.e. the original `pip install` flow if the platform is not included by above steps)  
   build_sdist:
     runs-on: ubuntu-20.04
+    if: ${{ success() }}
+
+    need:
+      - build_and_test
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -49,7 +49,7 @@ jobs:
 
 
   # Build on Different Platform.
-    build_linux_amd64:
+  build_linux_amd64:
     
     # This can be expensive so you might skip this if it is not tagged
     # by uncommenting the following
@@ -58,7 +58,7 @@ jobs:
     # Run only when the test is good.
     if: ${{ success() }}
 
-    need:
+    needs:
       - build_and_test
 
     strategy:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ success() }}
 
-    need:
+    needs:
       - build_and_test
 
     steps:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -33,7 +33,7 @@ jobs:
     
     - name: Build Library
       run: |
-        python setup.renamed.py bdist_wheel -j 4
+        python setup.py bdist_wheel -j 4
         auditwheel repair --plat manylinux_2_31_x86_64 dist/*.whl
 
     - name: Archive Artifacts
@@ -64,7 +64,7 @@ jobs:
 
     - name: Build Source Library
       run: |
-        python setup.renamed.py sdist
+        python setup.py sdist
 
     - name: Archive Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -9,6 +9,7 @@ jobs:
   # Create a Debug build and test it.
   build_and_test:
     runs-on: ubuntu-20.04
+    steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -51,7 +51,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.9"
     - name: Install Dependencies
       run: |
         sudo apt update -y

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,103 @@
+name: Build and Publish Python Package
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  build_linux_amd64:
+    strategy:
+        matrix:
+          python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install build-essential uuid-dev cmake default-jre \
+                libantlr4-runtime-dev antlr4 libssl-dev -yq
+        pip install setuptools wheel cmake ninja patchelf auditwheel
+        pip install -r requirements.txt
+
+    # Include ANTLR4's License file as we are redistributing their binary
+    - name: Adding ANTLR4 License
+      run: |
+        curl -s https://raw.githubusercontent.com/antlr/antlr4/master/LICENSE.txt >> LICENSE
+    
+    - name: Build Library
+      run: |
+        python setup.renamed.py bdist_wheel -j 4
+        auditwheel repair --plat manylinux_2_31_x86_64 dist/*.whl
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: PythonPackage
+        path: |
+          wheelhouse
+  
+  build_sdist:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install build-essential uuid-dev cmake default-jre \
+                libantlr4-runtime-dev antlr4 libssl-dev -yq
+        pip install setuptools wheel cmake ninja patchelf auditwheel
+        pip install -r requirements.txt
+
+    # Not including ANTLR4 license here as we don't redistribute ANTLR4 Binary in this package.
+
+    - name: Build Source Library
+      run: |
+        python setup.renamed.py sdist
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: PythonPackage
+        path: |
+          dist
+  
+  # Add your testing steps here
+
+  publish:
+
+    runs-on: ubuntu-latest
+
+    # Publish only when a tag "v*" is pushed. (which is a release)
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && success() }}
+
+    needs: 
+      - build_linux_amd64
+      - build_sdist
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hdlConvertor
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download Package Built
+      uses: actions/download-artifact@v3
+      with:
+        name: PythonPackage
+        path: dist
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Feature

Closing #187

- Building Linux X86-64 Binary Wheel
- Publish to PyPi if a tag is pushed in the format of `v*`

## Result Preview

You may preview the CI execution Result here.
https://github.com/khwong-c/hdlConvertor/actions/runs/7487908840

The Artifact `PythonPackage` contains all prebuilt binary wheel.
Open one of them and you can find the ANTLR4 Binary in the `hdlConvertor.libs` directory.
They will be installed and loaded by `pip install hdlConvertor` if it is available.

## Detail explained

We are not changing the build script, instead bundling the shared object (*.so) required by `hdlConvertor`
This can be done easily with `auditwheel` package.
External binary dependencies are injected into the wheel after `repair`.

Different platforms need different tools for repairing the wheel.
I have done the Linux one and you might follow the same pattern and complete the others

|platform|package|
|---|---|
| Linux | `auditwheel` |
| Mac | `delocate` |
| Windows | `delvewheel` |

## What if ...
1. I want to move on Meson build?
  - This script does not care if you are using CMake / Meson, as long as you are using `setup.py` as your entry point for the build.
2. I want to perform debug build and testing?
  - Please fill in the details in the `build_and_test` job.
3. I want to build with other Python interpreters? (e.g. Pypy)
  - Please add the Python version in the `matrix`.`python-version` accordingly.
  Reference: https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage
4. I want to test this on other branches (e.g. `mensonbuild` )
  - This PR only adds a single file, without any changes to other files. It should be an easy `git merge master` once the PR is merged to `master`.
