### PR TITLE
Use verilator repository from GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "verilator"]
 	path = tests/verilator
-	url = http://git.veripool.org/git/verilator
+	url = https://github.com/verilator/verilator
 	branch = master
 [submodule "vunit"]
 	path = tests/vunit


### PR DESCRIPTION
The official verilator documentation points new users to GitHub:
https://verilator.org/guide/latest/install.html#git-quick-install

Also it seems that the repository hosted on veripool.org does not work:
```
git clone http://git.veripool.org/git/verilator
Cloning into 'verilator'...
fatal: repository 'http://git.veripool.org/git/verilator/' not found
```

