### PR TITLE
Fix #202

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,8 @@ mainIncludeDir = 'include/'
 mainIncludeDir_inc = include_directories(mainIncludeDir)
 all_parser_libs = []
 all_parser_deps = []
+all_parser_header_targets = []
+
 foreach parserTuple : ANTLR_PARSERS
 	name = parserTuple[0]
 	folder_name = parserTuple[1]
@@ -147,7 +149,11 @@ foreach parserTuple : ANTLR_PARSERS
 		endif
 	endforeach
 	genIncludeDir = join_paths('include', 'hdlConvertor', folder_name, f'@name@Parser')
-  	subdir(genIncludeDir)
+	subdir(genIncludeDir)
+
+	# Add the header copy target to our list of dependencies
+	all_parser_header_targets += antrl_parser_headers
+
 	parser_cpp_src = run_command(python_prog, 'utils/rec_glob.py', join_paths('src', folder_name), '*.cpp', check:true)\
     	.stdout().strip().split('\n')
 	

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,7 +15,7 @@ hdlConvertor_core_src += run_command(py3, '../utils/rec_glob.py', './baseHdlPars
 	.stdout().strip().split('\n')
 
 hdlConvertor_core_static_lib = static_library('hdlConvertor_core_static',
-    hdlConvertor_core_src,
+    hdlConvertor_core_src + all_parser_header_targets,
     cpp_args: EXTRA_CXX_FLAGS,
     dependencies: [antlr4_cpp_dep, all_parser_deps],
     include_directories: [mainIncludeDir_inc],
@@ -32,7 +32,7 @@ if get_option('python_package')
 	# [note] hdlConvertor_core_static and hdlConvertor_cpp_static has to be separated
 	#        otherwise it is not possible to link this library
 	hdlConvertor_cpp_static = static_library('hdlConvertor_cpp_static',
-    	hdlConvertor_cpp_src,
+    	hdlConvertor_cpp_src + all_parser_header_targets,
 	    cpp_args: EXTRA_CXX_FLAGS,
 	    dependencies: [antlr4_cpp_dep, all_parser_deps],
 	    include_directories: [mainIncludeDir_inc],
@@ -42,7 +42,7 @@ if get_option('python_package')
 else
 	# add dummy file to make cmake happy
 	hdlConvertor_cpp_shared = shared_library('hdlConvertor_cpp_shared',
-		hdlConvertor_cpp_src,
+		hdlConvertor_cpp_src + all_parser_header_targets,
 	 	cpp_args: EXTRA_CXX_FLAGS,
 	    dependencies: [antlr4_cpp_dep, ] + all_parser_deps,
 	    include_directories: [mainIncludeDir_inc],


### PR DESCRIPTION
fix: https://github.com/Nic30/hdlConvertor/issues/202

https://github.com/copilot/share/40721212-0984-8c84-a943-2009c082401a

>Your build is failing because Meson does not know that hdlConvertor.cpp (and possibly others) depends on generated headers like verilogPreprocLexer.h. While you do generate them via a custom_target, you must pass these generated headers (or the custom target that produces them) as sources or dependencies to the targets that use them.

>Currently, this explicit dependency is missing, so Meson sometimes tries to compile code before the header is generated, causing the error you see.